### PR TITLE
Fix Bundler::GemRequireError when requiring sequel-devise.

### DIFF
--- a/lib/sequel-devise.rb
+++ b/lib/sequel-devise.rb
@@ -1,3 +1,4 @@
+require "sequel"
 require "sequel-devise/version"
 require 'sequel/plugins/devise'
 require 'orm_adapter-sequel'

--- a/lib/sequel-devise/version.rb
+++ b/lib/sequel-devise/version.rb
@@ -1,5 +1,5 @@
 module Sequel
   module Devise
-    VERSION = "0.0.11"
+    VERSION = "0.0.12"
   end
 end

--- a/lib/sequel/plugins/devise.rb
+++ b/lib/sequel/plugins/devise.rb
@@ -71,7 +71,7 @@ module Sequel
           include OverrideFixes
         end
 
-        Model::HOOKS.reject { |hook| hook == :after_commit }.each do |hook|
+        ::Sequel::Model::HOOKS.reject { |hook| hook == :after_commit }.each do |hook|
           define_method(hook) do |method = nil, options = {}, &block|
             if Symbol === (if_method = options[:if])
               orig_block = block

--- a/sequel-devise.gemspec
+++ b/sequel-devise.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Sequel::Devise::VERSION
 
+  gem.add_dependency 'sequel', '>= 3.11.0'
   gem.add_dependency 'devise'
   gem.add_dependency 'orm_adapter-sequel'
 end


### PR DESCRIPTION
This shall fix #2. The problem occurred because `Sequel::Model` was not in scope. The oldest tag in the sequel repository is 3.11.0 and it already has the `Sequel::Model::HOOKS` constant, so I used this in the gemspec. I doubt that any one wants to use this gem with an older version of sequel.