### PR TITLE
Alias model#new_record? to #new?

### DIFF
--- a/lib/sequel/plugins/devise.rb
+++ b/lib/sequel/plugins/devise.rb
@@ -6,6 +6,9 @@ module Sequel
         model.plugin :hook_class_methods # Devise requires a before_validation
         model.plugin :dirty # email_changed?
         model.plugin :validation_class_methods # for using validatable module
+
+        # for Devise::Models::Trackable
+        model.send :alias_method, :new_record?, :new?
       end
 
       module InstanceMethods


### PR DESCRIPTION
This fixes a bug with Devise 4.4.2 and upwards, which now expects the User model to have a `new_record?` method, see https://github.com/plataformatec/devise/blob/d870c0dced8499931495e07190aa8a9ff8caaadf/lib/devise/models/trackable.rb#L34-L37