### PR TITLE
don't delete values on inspect

### DIFF
--- a/lib/sequel/plugins/devise.rb
+++ b/lib/sequel/plugins/devise.rb
@@ -48,7 +48,7 @@ module Sequel
         private
 
         def devise_safe_values
-          values.delete_if{|k, v| devise_safe_keys.include?(k) || k =~ /password/i }
+          values.dup.delete_if{|k, v| devise_safe_keys.include?(k) || k =~ /password/i }
         end
 
         def devise_safe_keys


### PR DESCRIPTION
Inspecting a record on the console should not delete items from ```#values```

A simple ```values.dup.delete_if``` yelds the same result without breaking the records